### PR TITLE
Fix crash on configuration update

### DIFF
--- a/logging/registry.go
+++ b/logging/registry.go
@@ -153,7 +153,10 @@ func (r *Registry) Reload() {
 	// if no more path found or parts are exhausted use last config and stop searching
 	configs := make(map[string]*viper.Viper, len(keys))
 	for _, key := range keys {
-		configs[key] = findLongestMatchingPath(key, r.config)
+		cfg := findLongestMatchingPath(key, r.config)
+		if cfg != nil {
+			configs[key] = findLongestMatchingPath(key, r.config)
+		}
 	}
 
 	// call reconfigure on logger


### PR DESCRIPTION
While updating configuration file I got the following splat:

panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x8ca1ba]

goroutine 77 [running]:
third-party-source/go/github.com/spf13/viper.(*Viper).find(0x0, 0xcd5f45, 0x5, 0x5, 0xc42059fa80)
        third-party-source/go/github.com/spf13/viper/viper.go:895 +0x3a
third-party-source/go/github.com/spf13/viper.(*Viper).Get(0x0, 0xcd5f45, 0x5, 0xc42059fb30, 0xc42059fb20)
        third-party-source/go/github.com/spf13/viper/viper.go:615 +0x7c
third-party-source/go/github.com/spf13/viper.(*Viper).GetString(0x0, 0xcd5f45, 0x5, 0xc42059fba8, 0x8d857c)
        third-party-source/go/github.com/spf13/viper/viper.go:670 +0x3f
third-party-source/go/github.com/casualjim/go-app/logging.configureLogger(0xc420410aa0, 0xc4202849f0, 0x0)
        third-party-source/go/github.com/casualjim/go-app/logging/log.go:59 +0x83
third-party-source/go/github.com/casualjim/go-app/logging.(*defaultLogger).Configure(0xc42039f0a0, 0x0)
        third-party-source/go/github.com/casualjim/go-app/logging/log.go:154 +0x41
third-party-source/go/github.com/casualjim/go-app/logging.(*Registry).Reload(0xc420335580)
        third-party-source/go/github.com/casualjim/go-app/logging/registry.go:163 +0x432
third-party-source/go/github.com/casualjim/go-app.newWithCallback.func2(0xc4205a2cc0, 0x33, 0x1)
        third-party-source/go/github.com/casualjim/go-app/application.go:268 +0x57
third-party-source/go/github.com/spf13/viper.(*Viper).WatchConfig.func1.1(0xc420410be0, 0xc4203741c0, 0x33, 0xc4203f21e0)
        third-party-source/go/github.com/spf13/viper/viper.go:292 +0x2db
created by third-party-source/go/github.com/spf13/viper.(*Viper).WatchConfig.func1
        third-party-source/go/github.com/spf13/viper/viper.go:281 +0x1f6

This occurs when logging.findLongestMatchingPath returns nil on configuration reload